### PR TITLE
Fix compilation errors

### DIFF
--- a/src/interface_I.c
+++ b/src/interface_I.c
@@ -65,13 +65,13 @@ static void callback_alarm_triggered (GtkWidget * size_entry, gpointer data);
 
 gint dialog_I_response = GTK_RESPONSE_OK;
 
-PlugInUIVals *ui_state;
-PlugInVals *state;
-PlugInDialogVals *dialog_state;
-gboolean features_are_sensitive;
+extern PlugInUIVals *ui_state;
+extern PlugInVals *state;
+extern PlugInDialogVals *dialog_state;
+extern gboolean features_are_sensitive;
 InterfaceIData interface_I_data;
 
-GtkWidget *dlg;
+extern GtkWidget *dlg;
 GtkWidget *coordinates;
 
 gulong size_changed = 0;

--- a/src/interface_aux.c
+++ b/src/interface_aux.c
@@ -48,11 +48,11 @@ static void callback_dialog_aux_response (GtkWidget * dialog, gint response_id,
 
 gint dialog_aux_response = GTK_RESPONSE_OK;
 
-PlugInUIVals *ui_state;
-PlugInVals *state;
-PlugInDialogVals *dialog_state;
+extern PlugInUIVals *ui_state;
+extern PlugInVals *state;
+extern PlugInDialogVals *dialog_state;
 
-GtkWidget *dlg;
+extern GtkWidget *dlg;
 
 /***  Public functions  ***/
 


### PR DESCRIPTION
This commit applies a patch submitted in #5 and initially offered at
https://mail.gnome.org/archives/gimp-developer-list/2020-June/msg00004.html